### PR TITLE
Add id for each TIE instance.

### DIFF
--- a/client/question.html
+++ b/client/question.html
@@ -95,7 +95,7 @@
     <script src="question/services/code_preprocessors/PythonCodePreprocessorService.js"></script>
   </head>
   <body>
-    <learner-view question-id="reverseWords" show-output="true" show-error="false" show-feedback="true"></learner-view>
+    <learner-view tie-id="id1" question-id="reverseWords" show-output="true" show-error="false" show-feedback="true"></learner-view>
 
     <!-- Only import Skulpt if there is no server specified. -->
     <script ng-if="!SERVER_URL" src="../third_party/skulpt-12272b/skulpt.min.js"></script>

--- a/client/question/components/LearnerViewDirective.js
+++ b/client/question/components/LearnerViewDirective.js
@@ -20,6 +20,7 @@ tie.directive('learnerView', [function() {
   return {
     restrict: 'E',
     scope: {
+      tieId: '@',
       questionId: '@',
       showOutput: '=',
       showError: '=',
@@ -894,6 +895,7 @@ tie.directive('learnerView', [function() {
          * instructions, stored code, starter code and feedback.
          */
         var initLearnerViewDirective = function() {
+          LocalStorageService.init($scope.tieId);
           SessionHistoryService.init();
 
           // The pulseAnimationEnabled var is set to false to prevent

--- a/client/question/services/AutosaveService.js
+++ b/client/question/services/AutosaveService.js
@@ -38,9 +38,10 @@ tie.factory('AutosaveService', [
         }
 
         var questionId = CurrentQuestionService.getCurrentQuestionId();
+        var tieId = LocalStorageService.getTieId();
         var localStorageKey = (
           LocalStorageKeyManagerService.getLastSavedCodeKey(
-            questionId, language));
+            tieId, questionId, language));
         return LocalStorageService.get(localStorageKey);
       },
 
@@ -54,9 +55,10 @@ tie.factory('AutosaveService', [
        */
       saveCode: function(language, code) {
         var questionId = CurrentQuestionService.getCurrentQuestionId();
+        var tieId = LocalStorageService.getTieId();
         var localStorageKey = (
           LocalStorageKeyManagerService.getLastSavedCodeKey(
-            questionId, language));
+            tieId, questionId, language));
         LocalStorageService.put(localStorageKey, code);
       }
     };

--- a/client/question/services/LocalStorageKeyManagerService.js
+++ b/client/question/services/LocalStorageKeyManagerService.js
@@ -35,23 +35,25 @@ tie.factory('LocalStorageKeyManagerService', [
        * Returns the local storage key for the last saved code for a given
        * question.
        *
+       * @param {string} tieId
        * @param {string} questionId
        * @param {string} language
        * @returns {string}
        */
-      getLastSavedCodeKey: function(questionId, language) {
-        return 'tie:1:lastSavedCode:' + questionId + ':' + language;
+      getLastSavedCodeKey: function(tieId, questionId, language) {
+        return 'tie:' + tieId + ':lastSavedCode:' + questionId + ':' + language;
       },
 
       /**
        * Returns the local storage key for the session history.
        *
+       * @param {string} tieId
        * @param {string} questionId
        * @param {number} snapshotIndex
        * @returns {string}
        */
-      getSessionHistoryKey: function(questionId, snapshotIndex) {
-        return 'tie:1:sessionHistory:' + questionId + ':' +
+      getSessionHistoryKey: function(tieId, questionId, snapshotIndex) {
+        return 'tie:' + tieId + ':sessionHistory:' + questionId + ':' +
           snapshotIndex.toString();
       }
     };

--- a/client/question/services/LocalStorageKeyManagerServiceSpec.js
+++ b/client/question/services/LocalStorageKeyManagerServiceSpec.js
@@ -28,18 +28,22 @@ describe('LocalStorageKeyManagerService', function() {
   describe('last-saved code key generation', function() {
     it('should correctly generate last-saved code key', function() {
       expect(LocalStorageKeyManagerService.getLastSavedCodeKey(
-        'qid', 'python')).toBe('tie:1:lastSavedCode:qid:python');
+        'tieid', 'qid', 'python')).toBe(
+        'tie:tieid:lastSavedCode:qid:python');
       expect(LocalStorageKeyManagerService.getLastSavedCodeKey(
-        'qid2', 'python')).toBe('tie:1:lastSavedCode:qid2:python');
+        'tieid2', 'qid2', 'python')).toBe(
+        'tie:tieid2:lastSavedCode:qid2:python');
     });
   });
 
   describe('session history key generation', function() {
     it('should correctly generate session history key', function() {
       expect(LocalStorageKeyManagerService.getSessionHistoryKey(
-        'qid', 1)).toBe('tie:1:sessionHistory:qid:1');
+        'tieid', 'qid', 1)).toBe(
+        'tie:tieid:sessionHistory:qid:1');
       expect(LocalStorageKeyManagerService.getSessionHistoryKey(
-        'qid2', 2)).toBe('tie:1:sessionHistory:qid2:2');
+        'tieid2', 'qid2', 2)).toBe(
+        'tie:tieid2:sessionHistory:qid2:2');
     });
   });
 });

--- a/client/question/services/LocalStorageService.js
+++ b/client/question/services/LocalStorageService.js
@@ -23,6 +23,7 @@
 tie.factory('LocalStorageService', [
   'ServerHandlerService', function(ServerHandlerService) {
     var localStorageIsAvailable = false;
+    var tieId = null;
     // We only use localStorage in the standalone version of the application.
     if (!ServerHandlerService.doesServerExist()) {
       // In some browsers, localStorage is not available and its invocation
@@ -35,6 +36,22 @@ tie.factory('LocalStorageService', [
     }
 
     return {
+      /**
+       * Initializes the local storage by giving it an id.
+       */
+      init: function(inputTieId) {
+        if (inputTieId) {
+          tieId = inputTieId;
+        }
+      },
+      /**
+       * Returns the id for the local storage for this instance of TIE.
+       *
+       * @returns {string} tieId
+       */
+      getTieId: function() {
+        return tieId;
+      },
       /**
        * Checks if the local storage is available.
        *

--- a/client/question/services/LocalStorageServiceSpec.js
+++ b/client/question/services/LocalStorageServiceSpec.js
@@ -65,6 +65,12 @@ describe('LocalStorageService', function() {
         localStorage.clear();
       }));
 
+      it('should be initialized and return the correct TIE id', function() {
+        expect(LocalStorageService.getTieId()).toBe(null);
+        LocalStorageService.init('id');
+        expect(LocalStorageService.getTieId()).toBe('id');
+      });
+
       it('should be available', function() {
         expect(LocalStorageService.isAvailable()).toBe(true);
       });

--- a/client/question/services/SessionHistoryService.js
+++ b/client/question/services/SessionHistoryService.js
@@ -55,9 +55,10 @@ tie.factory('SessionHistoryService', [
         data.snapshotIndex = 0;
 
         var questionId = CurrentQuestionService.getCurrentQuestionId();
+        var tieId = LocalStorageService.getTieId();
         localStorageKey = (
           LocalStorageKeyManagerService.getSessionHistoryKey(
-            questionId, data.snapshotIndex));
+            tieId, questionId, data.snapshotIndex));
 
         var potentialSessionTranscript = LocalStorageService.get(
           localStorageKey);
@@ -69,7 +70,7 @@ tie.factory('SessionHistoryService', [
             data.snapshotIndex++;
             localStorageKey = (
               LocalStorageKeyManagerService.getSessionHistoryKey(
-                questionId, data.snapshotIndex));
+                tieId, questionId, data.snapshotIndex));
             potentialSessionTranscript = LocalStorageService.get(
               localStorageKey);
             if (potentialSessionTranscript !== null) {
@@ -105,9 +106,10 @@ tie.factory('SessionHistoryService', [
        */
       getStarterCodeSnapshot: function() {
         var questionId = CurrentQuestionService.getCurrentQuestionId();
+        var tieId = LocalStorageService.getTieId();
         localStorageKey = (
           LocalStorageKeyManagerService.getSessionHistoryKey(
-            questionId, 0
+            tieId, questionId, 0
           )
         );
         if (LocalStorageService.get(localStorageKey) === null) {
@@ -123,9 +125,10 @@ tie.factory('SessionHistoryService', [
       getPreviousSnapshot: function(snapshotIndex) {
         if (snapshotIndex > 0 && snapshotIndex <= data.snapshotIndex) {
           var questionId = CurrentQuestionService.getCurrentQuestionId();
+          var tieId = LocalStorageService.getTieId();
           localStorageKey = (
             LocalStorageKeyManagerService.getSessionHistoryKey(
-              questionId, snapshotIndex
+              tieId, questionId, snapshotIndex
             )
           );
           if (LocalStorageService.get(localStorageKey) === null) {
@@ -146,9 +149,10 @@ tie.factory('SessionHistoryService', [
       getPreviousFeedback: function(snapshotIndex) {
         if (snapshotIndex > 0 && snapshotIndex <= data.snapshotIndex) {
           var questionId = CurrentQuestionService.getCurrentQuestionId();
+          var tieId = LocalStorageService.getTieId();
           localStorageKey = (
             LocalStorageKeyManagerService.getSessionHistoryKey(
-              questionId, snapshotIndex
+              tieId, questionId, snapshotIndex
             )
           );
           if (LocalStorageService.get(localStorageKey) === null) {
@@ -171,10 +175,11 @@ tie.factory('SessionHistoryService', [
           TranscriptParagraphObjectFactory.createCodeParagraph(
             codeEditorContent, data.snapshotIndex));
         var questionId = CurrentQuestionService.getCurrentQuestionId();
+        var tieId = LocalStorageService.getTieId();
         // Store as a new snapshot.
         localStorageKey = (
           LocalStorageKeyManagerService.getSessionHistoryKey(
-            questionId, 0));
+            tieId, questionId, 0));
         LocalStorageService.put(
           localStorageKey,
           data.sessionTranscript.map(function(transcriptParagraph) {
@@ -192,10 +197,11 @@ tie.factory('SessionHistoryService', [
           TranscriptParagraphObjectFactory.createCodeParagraph(
             submittedCode, data.snapshotIndex));
         var questionId = CurrentQuestionService.getCurrentQuestionId();
+        var tieId = LocalStorageService.getTieId();
         // Store as a new snapshot.
         localStorageKey = (
           LocalStorageKeyManagerService.getSessionHistoryKey(
-            questionId, data.snapshotIndex));
+            tieId, questionId, data.snapshotIndex));
         LocalStorageService.put(
           localStorageKey,
           data.sessionTranscript.map(function(transcriptParagraph) {


### PR DESCRIPTION
Add an id for each learner view. This way, each instance of TIE is separate from each other.

I decided to use the user inputted id because in Runestone, users are already required to input an unique id for each instance of TIE created.